### PR TITLE
Add basic CSS styling and base template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,8 @@ dist/
 .idea/
 .vscode/
 static/
+# Allow static files in the qr app
+!qr/static/
+!qr/static/qr/
+!qr/static/qr/style.css
 media/

--- a/qr/static/qr/style.css
+++ b/qr/static/qr/style.css
@@ -1,0 +1,51 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f8f9fa;
+}
+
+nav {
+    background-color: #343a40;
+    padding: 10px;
+}
+
+nav a, nav button {
+    color: #ffffff;
+    margin-right: 10px;
+    text-decoration: none;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: 16px;
+}
+
+nav button:hover, nav a:hover {
+    text-decoration: underline;
+}
+
+.container {
+    max-width: 600px;
+    margin: 40px auto;
+    background: #ffffff;
+    padding: 20px;
+    border-radius: 4px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+}
+
+button[type="submit"] {
+    background-color: #007bff;
+    color: #ffffff;
+    border: none;
+    padding: 8px 16px;
+    border-radius: 4px;
+    cursor: pointer;
+}
+
+button[type="submit"]:hover {
+    background-color: #0056b3;
+}
+
+img {
+    max-width: 100%;
+}

--- a/qr/templates/qr/base.html
+++ b/qr/templates/qr/base.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>{% block title %}QR Generator{% endblock %}</title>
+    {% load static %}
+    <link rel="stylesheet" href="{% static 'qr/style.css' %}">
+</head>
+<body>
+    <nav>
+        {% if user.is_authenticated %}
+            <form action="{% url 'logout' %}" method="post" style="display:inline;">
+                {% csrf_token %}
+                <button type="submit">Logout</button>
+            </form>
+            |
+            <a href="{% url 'qr:create' %}">Create QR</a> |
+            <a href="{% url 'qr:my_qrs' %}">My QR Codes</a>
+        {% else %}
+            <a href="{% url 'login' %}">Login</a>
+        {% endif %}
+    </nav>
+    <div class="container">
+        {% block content %}{% endblock %}
+    </div>
+</body>
+</html>

--- a/qr/templates/qr/create_qr.html
+++ b/qr/templates/qr/create_qr.html
@@ -1,25 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Create QR</title>
-</head>
-<body>
-    <nav>
-        {% if user.is_authenticated %}
-            <form action="{% url 'logout' %}" method="post" style="display:inline;">
-                {% csrf_token %}
-                <button type="submit">Logout</button>
-            </form> |
-            <a href="{% url 'qr:my_qrs' %}">My QR Codes</a>
-        {% else %}
-            <a href="{% url 'login' %}">Login</a>
-        {% endif %}
-    </nav>
-    <h1>Create QR Code</h1>
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Generate</button>
-    </form>
-</body>
-</html>
+{% extends 'qr/base.html' %}
+
+{% block title %}Create QR{% endblock %}
+
+{% block content %}
+<h1>Create QR Code</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Generate</button>
+</form>
+{% endblock %}

--- a/qr/templates/qr/qr_detail.html
+++ b/qr/templates/qr/qr_detail.html
@@ -1,21 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>QR Detail</title>
-</head>
-<body>
-    <nav>
-        {% if user.is_authenticated %}
-            <form action="{% url 'logout' %}" method="post" style="display:inline;">
-                {% csrf_token %}
-                <button type="submit">Logout</button>
-            </form> |
-            <a href="{% url 'qr:my_qrs' %}">My QR Codes</a>
-        {% else %}
-            <a href="{% url 'login' %}">Login</a>
-        {% endif %}
-    </nav>
-    <h1>{{ qr.url }}</h1>
-    <img src="{{ qr.image.url }}" alt="QR Code">
-</body>
-</html>
+{% extends 'qr/base.html' %}
+
+{% block title %}QR Detail{% endblock %}
+
+{% block content %}
+<h1>{{ qr.url }}</h1>
+<img src="{{ qr.image.url }}" alt="QR Code">
+{% endblock %}

--- a/qr/templates/qr/qr_list.html
+++ b/qr/templates/qr/qr_list.html
@@ -1,27 +1,14 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>My QR Codes</title>
-</head>
-<body>
-    <nav>
-        {% if user.is_authenticated %}
-            <form action="{% url 'logout' %}" method="post" style="display:inline;">
-                {% csrf_token %}
-                <button type="submit">Logout</button>
-            </form> |
-            <a href="{% url 'qr:create' %}">Create QR</a>
-        {% else %}
-            <a href="{% url 'login' %}">Login</a>
-        {% endif %}
-    </nav>
-    <h1>My QR Codes</h1>
-    <ul>
-        {% for qr in qrs %}
-            <li><a href="{% url 'qr:detail' qr.pk %}">{{ qr.url }}</a></li>
-        {% empty %}
-            <li>No QR codes generated yet.</li>
-        {% endfor %}
-    </ul>
-</body>
-</html>
+{% extends 'qr/base.html' %}
+
+{% block title %}My QR Codes{% endblock %}
+
+{% block content %}
+<h1>My QR Codes</h1>
+<ul>
+    {% for qr in qrs %}
+        <li><a href="{% url 'qr:detail' qr.pk %}">{{ qr.url }}</a></li>
+    {% empty %}
+        <li>No QR codes generated yet.</li>
+    {% endfor %}
+</ul>
+{% endblock %}

--- a/qr/templates/registration/logged_out.html
+++ b/qr/templates/registration/logged_out.html
@@ -1,10 +1,8 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Logged Out</title>
-</head>
-<body>
-    <p>You have been logged out.</p>
-    <a href="{% url 'login' %}">Log in again</a>
-</body>
-</html>
+{% extends 'qr/base.html' %}
+
+{% block title %}Logged Out{% endblock %}
+
+{% block content %}
+<p>You have been logged out.</p>
+<a href="{% url 'login' %}">Log in again</a>
+{% endblock %}

--- a/qr/templates/registration/login.html
+++ b/qr/templates/registration/login.html
@@ -1,14 +1,12 @@
-<!DOCTYPE html>
-<html>
-<head>
-    <title>Login</title>
-</head>
-<body>
-    <h1>Login</h1>
-    <form method="post">
-        {% csrf_token %}
-        {{ form.as_p }}
-        <button type="submit">Log in</button>
-    </form>
-</body>
-</html>
+{% extends 'qr/base.html' %}
+
+{% block title %}Login{% endblock %}
+
+{% block content %}
+<h1>Login</h1>
+<form method="post">
+    {% csrf_token %}
+    {{ form.as_p }}
+    <button type="submit">Log in</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- create reusable base template
- add new stylesheet with basic layout styling
- modernize templates to extend base
- allow committing qr static assets via `.gitignore`

## Testing
- `python manage.py check`


------
https://chatgpt.com/codex/tasks/task_e_688a88a5e9d4832d8798d0f185977032